### PR TITLE
Swapping start times for 2025 Seattle half and full marathons

### DIFF
--- a/_data/schedules/25-autumn.yml
+++ b/_data/schedules/25-autumn.yml
@@ -85,10 +85,10 @@
 
 - date: "2025-11-30"
   plan:
-    - time: "7:00"
-      route_id: 2025-seattle-marathon-v2
     - time: "7:30"
       route_id: 2025-seattle-half-marathon-v2
+    - time: "7:30"
+      route_id: 2025-seattle-marathon-v2
       notes: "https://www.seattlemarathon.org/"
 
 ## - date: "2025-12-06"


### PR DESCRIPTION
The start times for the half and full were swapped this year.