### PR TITLE
Route addition automation, README cleanup and additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ rcc_weekends.ics
 
 # python virtual environment and caches
 .venv
-_bin/__pycache__
+__pycache__
 
 # Route preview image generation cache files
 .route-preview-cache-*

--- a/README.md
+++ b/README.md
@@ -7,36 +7,53 @@ This repo contains the website for Race Condition Running
 
 ## Building and Developing Locally
 
-You should use virtual environments to isolate dependencies for Python.
-  [`uv`](https://github.com/astral-sh/uv) is a great way to simplify dependency
-  and virtual environment management, and it enables you to use per-project
-  Python versions.
+
+### Prerequisites
+
+We have both ruby and python requirements. The versions for each are in the `.ruby-version` and `.python-version` files in the root of this directory. If you have both set up already, you can skip these two commands, but if you don't, you'll need to install them.
+
+#### Installing Ruby and Python
+For Ruby:
+```sh
+brew install rbenv ruby-build
+rbenv install -l
+rbenv install 3.2.3               ## check .ruby-version for version
+gem update --system               ## only if needed
+```
+
+For Python:
+```sh
+brew install pyenv pyenv-virtualenv
+pyenv install -l
+pyenv install 3.10.11             ## check .python-version for version
+```
+
+#### Installing Dependencies
+
+You then need to install the python and ruby dependencies.  For Python, we're going to use `uv` to manage the virtual environment. [`uv`](https://github.com/astral-sh/uv) is a great way to simplify dependency and virtual environment management, and it enables you to use per-project Python versions.
 
 1. Install [`uv`](https://github.com/astral-sh/uv). Run `uv help` to make sure
 your installation was successful.
-2. Run: `uv sync` and `bundle install`.
+2. Run dependency installation: `uv sync` for python dependencies and `bundle install` for ruby dependencies.
 3. Install [`entr`](https://github.com/eradman/entr), either via running:
 `brew install entr` (for macOS) or `sudo apt install entr`.
 
 ### Running Locally
 
-After you've installed the Python (`uv sync` ),
-  Ruby (`bundle install`) dependencies and `entr` (see section above for commands),
-  run:
+After installing the dependencies, you can build and serve the site locally:
 
 > `make serve`
 
-From the root of this directory.
 A successful deployment will serve a local instance of `raceconditionrunning.github.io`
 on [http://localhost:4000](`localhost:4000`).
 
-The live site is built and deployed by a GitHub action and served by GitHub pages.
+When a push is made to the main branch of this github repo, the live website is built and deployed by a GitHub action and served by GitHub pages.
 
-### Creating a Schedule
+## Creating a Schedule
 
-Schedules are YAML files stored in the `_data/schedules/` directory. Each schedule contains a list of **plans**. Check out the [long-run scheduler](https://github.com/raceconditionrunning/run-scheduler) if you'd like to automatically generate a schedule.
+Schedules are YAML files stored in the `_data/schedules/` directory and are named with the format `<YY>-<season>.yml`. Each schedule contains a list of **plans**. Check out the [long-run scheduler](https://github.com/raceconditionrunning/run-scheduler) if you'd like to automatically generate a draft schedule.
 
-The current schedule is whatever is symlinked from `_data/schedule.yml`.
+The current schedule is symlinked from `_data/schedule.yml`.
 To update the symlink (e.g., whenever a new quarter schedule is published),
   run:
 
@@ -44,28 +61,50 @@ To update the symlink (e.g., whenever a new quarter schedule is published),
 % ln -sf <path_to_new_schedule> _data/schedule.yml
 ```
 
-#### Plans
+### Plans
 
-A **plan** represents a long run that may be broken into multiple legs. While uncommon, there can be multiple distinct plans on the same day.
+A **plan** represents a long run consisting of one or more **legs**. While uncommon, there can be multiple distinct plans on the same day.
 
 Each plan is a dictionary containing:
 - `date` - Date in `YYYY-MM-DD` format
 - `plan` - List of leg dictionaries (see below)
 - `highlight_image` - (Optional) Absolute path to an image displayed inline with the plan
 - `notes` - (Optional) String displayed as a note for the plan
+- `organized-event` - (Optional) Boolean indicating whether the plan is an organized event
 
-
-##### Plan Legs
+#### Plan Legs
 
 Each leg in a plan's `plan` list contains:
 - `time` - Start time in 24-hour format (`HH:MM`)
 - `route` OR `route_id` - Route information (see Route Options below)
 
-#### Route Options
+#### Example plans
+```yaml
+- date: "2026-06-27"
+  plan:
+    - time: "8:30"
+      route_id: cse-lwb-cc
+      notes: run in reverse (Columbia City to CSE)
+    - time: "10:00"
+      route_id: cse-lake-union-westlake
+
+- date: '2026-06-06'
+  organized-event: true
+  plan:
+    - time: '8:00'
+      route:
+        name: Drumheller Marathon and Half-marathon
+        map: /drumheller-marathon-26/
+        distance_mi: 26.2
+      highlight-image: /img/dm26/og-banner.jpg
+```
+
+
+### Route Options
 
 You can specify routes in two ways:
 
-**Option 1: Reference existing route**
+**Option 1: Reference defined route**
 - `route_id` - String key matching a route in `_data/routes.yml`
 
 **Option 2: Inline route definition**
@@ -74,10 +113,8 @@ You can specify routes in two ways:
   - `map` - Web map URL (string)
   - `distance_mi` - Distance in miles (float)
 
-When a route hasn't been chosen yet,
-  omit `route_id` and either leave out `route` entirely or
-  include an inline `route` with just a `name` of `TBD`.
-The schedule layout will render these entries with a "TBD" placeholder.
+You can follow the instructions in the [Adding a Route](#adding-a-route) section to add a new route to `_data/routes.yml` and then use Option 1 above.
+When a route hasn't been chosen yet, omit `route_id` and either leave out `route` entirely or include an inline `route` with just `name:TBD`. The schedule layout will render these entries with a "TBD" placeholder.
 Example TBD schedule entry:
 
 ```yaml
@@ -88,46 +125,85 @@ Example TBD schedule entry:
         name: TBD
 ```
 
-#### Cancellations
+### Cancellations
 
-Both plans and individual legs can include a `cancelled` key:
-- Any value (including empty string) causes strikethrough display
-- The value content is shown as the cancellation reason
+Both plans and individual legs can include a `cancelled` key. Any value for `cancelled`, including empty string, causes strikethrough display. The value is shown as the cancellation reason.
 
-### Adding a Route
+## Adding a Route
 
-Add a GPX file to the `routes/_gpx/` directory. The build will fail with a descriptive error if any route doesn't meet the minimum formatting requirements which get checked by `_bin/make_routes_table.py`. 
-  
-  * The file's `<gpx>` tag must include the RCR extension: `<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Race Condition Running" xmlns:rcr="http://raceconditionrunning.com/extensions">`
+To add a new route, you must add a GPX file to the `routes/_gpx/` directory. This new `<route-name>.gpx` file must follow our formatting requirments, else the build will fail with a descriptive error. These requirements are checked by `_bin/make_routes_table.py` and are listed here by tag:
+
+  * `<gpx>` - must include the RCR extension: `<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Race Condition Running" xmlns:rcr="http://raceconditionrunning.com/extensions">`
   * `<name>` - lowercase, hyphenated name of the route. Ends with `loop` if the route is a loop or `ob` if the route is an out-and-back.
   * `<desc>` - The presentation name of the route, e.g. "Lake Union Loop".
-  * You must include an `<extensions>` tag in the `<metadata>` section, with
+  * `<metadata>` -- must include an `<extensions>` tag in this section, with
     `<rcr:last_updated>YYYY-MM-DD</rcr:last_updated>`.
+
+Open any of he existing GPX files in `routes/_gpx/` to see examples of these tags.
 
 Before you commit changes to a route, run `make normalize-routes-in-place` to ensure the route is formatted correctly.
 
-To supply elevation data, run `make replace-route-elevations` and `make normalize-routes-in-place`.
+If your `.gpx` file is missing elevation information, run `make replace-route-elevations` and `make normalize-routes-in-place`.
 
 If your route starts or ends at a new location, add a new feature to the `routes/locations.json` file.
 
-#### Typical workflow for adding routes
+### Typical workflow for adding routes
 
-Here are the concrete steps for making and adding routes to the repo:
+First, you need to have the route defined somehow. If you are inheriting a GPX file from another trusted source, you can skip this step.
+If this is a new route, you can draft it with [OnTheGoMap](https://onthegomap.com).
+Please be careful when making new routes!
+Pay attention to the exact areas the route runs through, sidewalk quality, traffic speed and noise, neighborhood density, and other factors. Think carefully whether the route is actually runnable and safe, and where there might be alternatives.
+For example, most routes with long stretches on the shoulder of a busy road would not be sufficiently safe.
+Use Street View on [Google Maps](https://www.google.com/maps/) scope out a run.
 
-1. Make a new route via [OnTheGoMap](https://onthegomap.com).
-  Please be careful when making them,
-      pay attention,
-      think carefully whether the route is actually runnable and safe.
-   For example,
-       if a route involves running alongside traffic (i.e., on the shoulder of a road) for long stretches,
-       it is likely not very safe.
-   Use Street View on [Google Maps](https://www.google.com/maps/) to help scope out a run.
+With the route now defined, there are two ways to generate and re-format route GPX files, which we detail below: the **automated script** or the **manual workflow**. Both should result in near-equivalent GPX files. If you
 
-2. Go to the hamburger menu at the top-right corner of [OnTheGoMap](https://onthegomap.com) and select "Export as GPX". Save the "shortened link" of the route for later use in Step 4 for `rcr:map`).
+After generating each route, you can run `make serve` to check that the route was generated locally and the site looks right. (Follow the instructions for `Building and Developing Locally` first, if you haven't already.)
 
-3. Move the GPX file to `routes/_gpx` and give it a name based on its type (e.g., out-and-back, point-to-point, loop, etc.) and where it starts and what main areas it goes through. If the route is a loop, put `-loop` and if it is an out-and-back, put `-ob` at the end.
+If you are making more than one route, batch all of your commits and only push once. The CI build is somewhat slow.
 
-4. Edit the GPX (which is just XML) like so: from any existing route in `routes/_gpx`, take all the content down to the `<trkseg>` tag and replace all the content in the original GPX file up until the start of `<trkseg>` with it. Then modify the fields specific to the route. This includes:
+#### Option A: Using `import_route.py`
+
+`_bin/import_route.py` automates the entire route import process — fetching coordinates, adding elevation data, and writing a correctly formatted GPX file. It can accept an OnTheGoMap url or a GPX file.
+
+**From an OnTheGoMap URL** (share link or full URL):
+
+```sh
+uv run python3 _bin/import_route.py \
+  --url "https://onthegomap.com/s/ke0cnl2r" \     # can be share version (shown) or long version
+  --id cse-sobel-mercer-island \
+  --name "CSE, South Bellevue, Mercer Island"
+```
+
+**From an existing GPX file** (e.g. exported from OnTheGoMap, Strava, etc.):
+
+```sh
+uv run python3 _bin/import_route.py \
+  --gpx ~/Downloads/my-route.gpx \
+  --id my-new-route-loop \
+  --name "My New Route"
+```
+
+The script will:
+1. Extract track points from the URL or the GPX file
+2. Fetch missing elevation data from [USGS 3DEP](https://epqs.nationalmap.gov/) (~10m resolution, with [Open-Meteo](https://open-meteo.com/) fallback)
+3. Write a GPX file to `routes/_gpx/<id>.gpx` with all required RCR metadata
+4. Run `normalize_gpx.py` to finalize the file (computes ascent, detects start/end locations)
+
+Additional flags:
+- `--map-url URL` — override the `rcr:map` value (auto-generated as a short OnTheGoMap link if omitted)
+- `--overwrite-elevation` — replace existing elevation data when importing a GPX file
+- `--skip-normalize` — skip the normalization step
+
+Extraction from a URL relies on the structure currently used by OnTheGoMap. Specifically, OnTheGoMap full (non-share) URLs include an `r2` query parameter with a polyline encoding the full route. The script will fail if OnTheGoMap changes their URL structure.
+
+#### Option B: Manual workflow
+
+1. Go to the hamburger menu at the top-right corner of [OnTheGoMap](https://onthegomap.com) and select "Export as GPX". Save the "shortened link" of the route for later use in Step 4 for `rcr:map`).
+
+2. Move the GPX file to `routes/_gpx` and give it a name based on its type (e.g., out-and-back, point-to-point, loop, etc.) and where it starts and what main areas it goes through. If the route is a loop, put `-loop` and if it is an out-and-back, put `-ob` at the end.
+
+3. Edit the GPX (which is just XML) like so: from any existing route in `routes/_gpx`, take all the content down to the `<trkseg>` tag and replace all the content in the original GPX file up until the start of `<trkseg>` with it. Then modify the fields specific to the route. This includes:
       * metadata `name` (same as GPX file name)
       * metadata `desc`
       * metadata `link` including `text`
@@ -135,18 +211,43 @@ Here are the concrete steps for making and adding routes to the repo:
       * track `name` (same as GPX file name)
       * track `desc`
 
-5. Run `./_bin/gpx-inplace-fixup.sh routes/_gpx/recently-added-route.gpx` to add elevation data to the route. Make sure you have python installed since this script invokes other python scripts.
+4. Run `./_bin/gpx-inplace-fixup.sh routes/_gpx/recently-added-route.gpx` to add elevation data to the route. Make sure you have python installed since this script invokes other python scripts.
 
-6. Follow the instructions for `Building and Developing Locally`. Then run `make serve` to check that it works locally and the site looks right.
 
-7. If you are making more than one route, commit and push once for batching. The CI build is somewhat slow.
+## Project Structure
 
-## Important Files and Folders
-
-- `_bin/mkical.py` generates an iCalendar file for the current schedule.
-- Routes are in `_data/routes.yml`.
-- The current schedule is in `_data/schedule.yml`. This is a symlink to the current season's schedule in `_data/schedules/`.
-- To create a new brunch review, add a new file to the `_brunch-reviews` folder.
+```
+.
+├── _bin/                        # Build and utility scripts
+│   ├── import_route.py          # Import routes from OnTheGoMap or GPX files
+│   ├── normalize_gpx.py         # Normalize GPX files (metrics, locations)
+│   ├── replace_route_elevations.py
+│   ├── gpx-inplace-fixup.sh     # Chains elevation → surface → normalize
+│   ├── mkical.py                # Generate iCal feed from schedule
+│   ├── make_routes_table.py     # Generate _data/routes.yml from GPX files
+│   ├── make_schedules_table.py  # Generate _data/schedules_table.yml
+│   ├── rcr.py                   # Shared library (route loading, paths)
+│   └── gis.py                   # Geo utilities (distance, ascent, locations)
+├── _brunch-reviews/             # Brunch review posts (add a file to create one)
+├── _data/
+│   ├── schedule.yml             # Symlink → current season's schedule
+│   ├── schedules/               # Per-season schedule YAML files
+│   ├── routes.yml               # Generated route index (do not edit by hand)
+│   └── locations.json           # Generated from routes/locations.geojson
+├── _layouts/                    # Jekyll page templates
+├── _includes/                   # Jekyll partial templates
+├── routes/
+│   ├── _gpx/                    # GPX files for existing routes
+│   ├── locations.geojson        # Start/end location definitions
+│   └── geojson/                 # Generated GeoJSON (do not edit by hand)
+├── utils/
+│   └── onthegomap.py            # OnTheGoMap URL/GPX conversion utilities
+├── pages/                       # Static site pages
+├── img/                         # Site images
+├── Makefile                     # Build targets (serve, normalize, etc.)
+├── _config.yml                  # Jekyll configuration
+└── pyproject.toml               # Python dependencies (managed by uv)
+```
 
 ## Preparing Images
 

--- a/_bin/import_route.py
+++ b/_bin/import_route.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Create or import a GPX route file for the RCR website.
+
+Usage:
+  # From an OnTheGoMap URL (share link or full URL):
+  uv run python3 _bin/import_route.py \\
+    --url "https://onthegomap.com/s/ke0cnl2r" \\
+    --id cse-sobel-mercer-island \\
+    --name "CSE, South Bellevue, Mercer Island"
+
+  # From an existing GPX file:
+  uv run python3 _bin/import_route.py \\
+    --gpx ~/Downloads/my-route.gpx \\
+    --id cse-sobel-mercer-island \\
+    --name "CSE, South Bellevue, Mercer Island"
+
+The script:
+  1. Extracts track points from the source (URL polyline or GPX file)
+  2. Fetches missing elevation data (USGS 3DEP, with Open-Meteo fallback)
+  3. Writes a GPX file in the RCR project format to routes/_gpx/<id>.gpx
+  4. Runs normalize_gpx.py to finalize the file
+
+Elevation is fetched from USGS 3DEP (~10m resolution), with Open-Meteo as fallback.
+Points are batched (up to 100 per request) with retry + backoff on 429 errors.
+"""
+
+import argparse
+import pathlib
+import subprocess
+import sys
+import urllib.parse
+
+# Allow importing from project root (parent of _bin/)
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from utils.onthegomap import (
+    compute_distance_mi,
+    coords_to_url,
+    fetch_elevations,
+    gpx_to_coords,
+    long_to_short_url,
+    url_to_coords,
+    write_rcr_gpx,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Import a route into the RCR website as a GPX file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--url",
+        help="OnTheGoMap URL (share link or full redirect URL with r2= param)",
+    )
+    source.add_argument(
+        "--gpx",
+        help="Path to an existing GPX file to reformat and fill in elevation",
+    )
+
+    parser.add_argument("--id", required=True, help="Route ID (kebab-case filename stem, e.g. cse-sobel-mercer-island)")
+    parser.add_argument("--name", required=True, help='Human-readable route name (e.g. "CSE, South Bellevue, Mercer Island")')
+    parser.add_argument(
+        "--map-url",
+        default=None,
+        help="OnTheGoMap share URL for the rcr:map extension (auto-generated if omitted)",
+    )
+    parser.add_argument(
+        "--overwrite-elevation",
+        action="store_true",
+        help="Replace existing elevation data in an imported GPX file",
+    )
+    parser.add_argument(
+        "--skip-normalize",
+        action="store_true",
+        help="Skip running normalize_gpx.py after writing (useful if normalize_gpx.py is unavailable)",
+    )
+
+    args = parser.parse_args()
+
+    # Determine project root (this script lives in _bin/)
+    script_dir = pathlib.Path(__file__).resolve().parent
+    project_root = script_dir.parent
+    output_path = project_root / "routes" / "_gpx" / f"{args.id}.gpx"
+
+    if output_path.exists():
+        print(f"WARNING: {output_path} already exists and will be overwritten")
+
+    # --- Extract coordinates ---
+    existing_elevations = None
+    map_url = args.map_url
+
+    if args.url:
+        print(f"Fetching route from OnTheGoMap: {args.url}")
+        coords = url_to_coords(args.url)
+        print(f"  decoded {len(coords)} track points")
+        if not map_url:
+            parsed = urllib.parse.urlparse(args.url)
+            if parsed.path.startswith("/s/"):
+                map_url = args.url
+            else:
+                print("Generating short URL for map link...")
+                map_url = long_to_short_url(args.url)
+                print(f"  {map_url}")
+    else:
+        print(f"Importing GPX: {args.gpx}")
+        coords, existing_elevations = gpx_to_coords(args.gpx)
+        print(f"  loaded {len(coords)} track points")
+
+    # --- Fetch elevation data ---
+    need_elevation_indices = []
+    elevations = [None] * len(coords)
+
+    if existing_elevations is not None and not args.overwrite_elevation:
+        for i, ele in enumerate(existing_elevations):
+            if ele is not None:
+                elevations[i] = ele
+        need_elevation_indices = [i for i, e in enumerate(elevations) if e is None]
+    else:
+        need_elevation_indices = list(range(len(coords)))
+
+    if need_elevation_indices:
+        n_missing = len(need_elevation_indices)
+        print(f"Fetching elevation for {n_missing} point(s)...")
+        missing_coords = [coords[i] for i in need_elevation_indices]
+        fetched = fetch_elevations(missing_coords)
+        for idx, ele in zip(need_elevation_indices, fetched):
+            elevations[idx] = ele
+    else:
+        print("All points already have elevation data")
+
+    # Sanity check: no Nones left
+    missing = sum(1 for e in elevations if e is None)
+    if missing:
+        print(
+            f"WARNING: {missing} point(s) still missing elevation — "
+            f"using 0.0 as fallback",
+            file=sys.stderr,
+        )
+        elevations = [e if e is not None else 0.0 for e in elevations]
+
+    # --- Auto-generate short URL if no map URL yet (e.g. --gpx without --map-url) ---
+    if not map_url:
+        print("Generating short URL for map link...")
+        long_url = coords_to_url(coords)
+        map_url = long_to_short_url(long_url)
+        print(f"  {map_url}")
+
+    distance_mi = compute_distance_mi(coords)
+    print(f"Route: {args.name} ({distance_mi:.1f} mi), {len(coords)} points")
+
+    # --- Write GPX ---
+    write_rcr_gpx(coords, elevations, args.id, args.name, str(output_path), map_url)
+    print(f"Wrote {output_path}")
+
+    # --- Normalize ---
+    if not args.skip_normalize:
+        print("Running normalize_gpx.py...")
+        normalize_script = script_dir / "normalize_gpx.py"
+        if normalize_script.exists():
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(normalize_script),
+                    "--input", str(output_path),
+                    "--output", str(output_path),
+                ],
+                cwd=str(project_root),
+            )
+            if result.returncode != 0:
+                print(
+                    "WARNING: normalize_gpx.py exited with errors (see above). "
+                    "The GPX file was still written but may need manual fixes.",
+                    file=sys.stderr,
+                )
+        else:
+            print(
+                f"WARNING: {normalize_script} not found, skipping normalization",
+                file=sys.stderr,
+            )
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/_bin/mkical.py
+++ b/_bin/mkical.py
@@ -96,7 +96,7 @@ def main():
                           })
 
             # add brunch after other phases
-            if i == len(phases) - 1 and dist > 0:
+            if i == len(phases) - 1 and dist and dist > 0:
                 bstart = end
                 bend = bstart + timedelta(0, 90 * 60)
                 buid = str(bstart) + '@raceconditionrunning.com'

--- a/_bin/normalize_gpx.py
+++ b/_bin/normalize_gpx.py
@@ -1,8 +1,25 @@
 import argparse
+import json
 import pathlib
 
 import gis
 import rcr
+
+
+def _add_location_hint(lat, lon):
+    loc_path = rcr.LOC_DB
+    coords = f"[{round(lon, 6)}, {round(lat, 6)}]"
+    maps_url = f"https://www.google.com/maps/place/{lat:.6f},+{lon:.6f}/@{lat:.6f},{lon:.6f}"
+    return (
+        f'python3 -c "'
+        f"import json; p='{loc_path}'; d=json.load(open(p)); "
+        f"d['features'].append({{'type':'Feature',"
+        f"'geometry':{{'type':'Point','coordinates':{coords}}},"
+        f"'properties':{{'id':'LOCATION_ID','name':'LOCATION_NAME',"
+        f"'maps_url':'{maps_url}','meeting_point_desc':None,'transit':None,"
+        f"'reachability':None,'neighborhood':None}}}}); "
+        f'json.dump(d,open(p,\'w\'),indent=2)"'
+    )
 
 
 class RogueRouteError(Exception):
@@ -120,8 +137,12 @@ def main():
         computed_end = gis.get_nearest_loc(locs, lls[-1].latitude, lls[-1].longitude)
         if computed_start[1] > 0.15:
             print(f"WARNING! {route['id']} distant from start loc: {computed_start[1]:.2f}")
+            print(f"You can add a new start location by editing the command below and pasting into your shell:")
+            print(f"  {_add_location_hint(lls[0].latitude, lls[0].longitude)}")
         if computed_end[1] > 0.15:
             print(f"WARNING! {route['id']} distant from end loc: {computed_end[1]:.2f}")
+            print(f"You can add a new end location by editing the command below and pasting into your shell:")
+            print(f"  {_add_location_hint(lls[-1].latitude, lls[-1].longitude)}")
         if route.get("start", None) and route["start"] != computed_start[0]:
             print(f"WARNING! {route['id']} start mismatch: {route['start']} vs {computed_start[0]}")
         if route.get("end", None) and route["end"] != computed_end[0]:

--- a/utils/onthegomap.py
+++ b/utils/onthegomap.py
@@ -1,0 +1,371 @@
+"""OnTheGoMap URL and GPX conversion utilities.
+
+Provides functions to convert between OnTheGoMap URLs (short and long),
+coordinate lists, and GPX files in the RCR project format.
+"""
+
+import json
+import math
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date
+
+import gpxpy
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_USER_AGENT = "Mozilla/5.0 (compatible; RCR-import/1.0)"
+_OTGM_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_~-"
+_OTGM_DECODE_MAP = {_OTGM_ALPHABET[i]: chr(i + 63) for i in range(65)}
+_OTGM_ENCODE_MAP = {chr(i + 63): _OTGM_ALPHABET[i] for i in range(65)}
+
+_USGS_ELEVATION_URL = "https://epqs.nationalmap.gov/v1/json"
+_USGS_INTER_POINT_DELAY = 0.1
+_OPEN_METEO_URL = "https://api.open-meteo.com/v1/elevation"
+ELEVATION_BATCH_SIZE = 100
+ELEVATION_INTER_BATCH_DELAY = 1.0
+ELEVATION_MAX_RETRIES = 5
+ELEVATION_INITIAL_BACKOFF = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Polyline encoding/decoding
+# ---------------------------------------------------------------------------
+
+def _otgm_r2_to_polyline(r2):
+    return "".join(_OTGM_DECODE_MAP.get(ch, ch) for ch in r2)
+
+
+def _polyline_to_otgm_r2(polyline):
+    return "".join(_OTGM_ENCODE_MAP.get(ch, ch) for ch in polyline)
+
+
+def _decode_polyline(encoded, precision=5):
+    inv = 1.0 / (10 ** precision)
+    decoded = []
+    previous = [0, 0]
+    i = 0
+    while i < len(encoded):
+        for idx in range(2):
+            shift = 0
+            result = 0
+            while True:
+                b = ord(encoded[i]) - 63
+                i += 1
+                result |= (b & 0x1f) << shift
+                shift += 5
+                if b < 0x20:
+                    break
+            if result & 1:
+                previous[idx] += ~(result >> 1)
+            else:
+                previous[idx] += (result >> 1)
+        decoded.append((previous[0] * inv, previous[1] * inv))
+    return decoded
+
+
+def _encode_polyline(coords, precision=5):
+    factor = 10 ** precision
+    encoded = []
+    prev_lat = 0
+    prev_lng = 0
+    for lat, lng in coords:
+        lat_int = round(lat * factor)
+        lng_int = round(lng * factor)
+        for v in (lat_int - prev_lat, lng_int - prev_lng):
+            v = ~(v << 1) if v < 0 else (v << 1)
+            while v >= 0x20:
+                encoded.append(chr((v & 0x1f) + 63 + 0x20))
+                v >>= 5
+            encoded.append(chr(v + 63))
+        prev_lat = lat_int
+        prev_lng = lng_int
+    return "".join(encoded)
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+
+# ---------------------------------------------------------------------------
+# URL conversion
+# ---------------------------------------------------------------------------
+
+def short_to_long_url(short_url):
+    """Resolve an OnTheGoMap short URL (e.g. /s/XXXX) to the full URL with r2 param."""
+    parsed = urllib.parse.urlparse(short_url)
+    params = urllib.parse.parse_qs(parsed.query)
+    if "r2" in params or "r" in params:
+        return short_url
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    req = urllib.request.Request(
+        short_url,
+        headers={"User-Agent": _USER_AGENT},
+    )
+    try:
+        resp = opener.open(req, timeout=15)
+        return resp.url
+    except urllib.error.HTTPError as e:
+        if e.code in (301, 302, 303, 307, 308):
+            return e.headers.get("Location", short_url)
+        raise
+
+
+def long_to_short_url(long_url):
+    """Shorten a full OnTheGoMap URL via the cfworker/shorten API."""
+    req = urllib.request.Request(
+        "https://onthegomap.com/cfworker/shorten",
+        data=json.dumps({"long_url": long_url}).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": _USER_AGENT,
+        },
+    )
+    resp = urllib.request.urlopen(req, timeout=15)
+    return json.loads(resp.read())["link"]
+
+
+# ---------------------------------------------------------------------------
+# Coords <-> URL
+# ---------------------------------------------------------------------------
+
+def url_to_coords(url):
+    """Extract (lat, lng) coords from any OnTheGoMap URL (short or long)."""
+    full_url = short_to_long_url(url)
+    parsed = urllib.parse.urlparse(full_url)
+    params = urllib.parse.parse_qs(parsed.query)
+    if "r2" in params:
+        polyline_str = _otgm_r2_to_polyline(params["r2"][0])
+        return _decode_polyline(polyline_str, 5)
+    elif "r" in params:
+        return _decode_polyline(params["r"][0], 5)
+    raise ValueError(f"No route data (r or r2 param) in URL: {full_url}")
+
+
+def coords_to_url(coords):
+    """Build a full OnTheGoMap URL from (lat, lng) coords."""
+    polyline = _encode_polyline(coords)
+    r2 = _polyline_to_otgm_r2(polyline)
+    return f"https://onthegomap.com/?m=r&u=mi&context=share&r2={urllib.parse.quote(r2, safe='')}"
+
+
+# ---------------------------------------------------------------------------
+# Elevation
+# ---------------------------------------------------------------------------
+
+def _fetch_usgs_elevation(lat, lng):
+    """Fetch a single elevation value from USGS 3DEP."""
+    url = (
+        f"{_USGS_ELEVATION_URL}"
+        f"?x={lng:.6f}&y={lat:.6f}&wkid=4326&units=Meters&includeDate=false"
+    )
+    req = urllib.request.urlopen(url, timeout=10)
+    data = json.loads(req.read())
+    return float(data["value"])
+
+
+def _fetch_elevations_usgs(coords):
+    """Fetch elevations from USGS 3DEP (per-point, ~10m resolution)."""
+    elevations = []
+    n = len(coords)
+    for i, (lat, lng) in enumerate(coords):
+        ele = _fetch_usgs_elevation(lat, lng)
+        elevations.append(ele)
+        if (i + 1) % 50 == 0 or i == n - 1:
+            print(f"  elevation [USGS]: {i + 1}/{n} points")
+        if i < n - 1:
+            time.sleep(_USGS_INTER_POINT_DELAY)
+    return elevations
+
+
+def _fetch_elevations_open_meteo(coords):
+    """Fetch elevations from Open-Meteo (batched, lower resolution)."""
+    elevations = []
+    n = len(coords)
+    n_batches = math.ceil(n / ELEVATION_BATCH_SIZE)
+    for batch_idx in range(n_batches):
+        start = batch_idx * ELEVATION_BATCH_SIZE
+        batch = coords[start:start + ELEVATION_BATCH_SIZE]
+        lats = ",".join(f"{lat:.6f}" for lat, _ in batch)
+        lngs = ",".join(f"{lng:.6f}" for _, lng in batch)
+        url = f"{_OPEN_METEO_URL}?latitude={lats}&longitude={lngs}"
+        backoff = ELEVATION_INITIAL_BACKOFF
+        for attempt in range(ELEVATION_MAX_RETRIES):
+            try:
+                req = urllib.request.urlopen(url, timeout=30)
+                data = json.loads(req.read())
+                elevations.extend(data["elevation"])
+                end = start + len(batch) - 1
+                print(
+                    f"  elevation [Open-Meteo]: points {start}-{end} of {n} "
+                    f"(batch {batch_idx + 1}/{n_batches})"
+                )
+                break
+            except urllib.error.HTTPError as e:
+                if e.code == 429:
+                    if attempt == ELEVATION_MAX_RETRIES - 1:
+                        print(
+                            f"  ERROR: rate-limited on batch {batch_idx + 1} "
+                            f"after {ELEVATION_MAX_RETRIES} retries",
+                            file=sys.stderr,
+                        )
+                        raise
+                    print(
+                        f"  rate-limited (429), waiting {backoff:.0f}s "
+                        f"(attempt {attempt + 1}/{ELEVATION_MAX_RETRIES})..."
+                    )
+                    time.sleep(backoff)
+                    backoff *= 2
+                else:
+                    raise
+        if batch_idx < n_batches - 1:
+            time.sleep(ELEVATION_INTER_BATCH_DELAY)
+    return elevations
+
+
+def fetch_elevations(coords):
+    """Fetch elevation (meters) for each (lat, lng) coordinate.
+
+    Tries USGS 3DEP first (~10m resolution). Falls back to Open-Meteo
+    if USGS is unavailable.
+    """
+    try:
+        _fetch_usgs_elevation(*coords[0])
+    except Exception:
+        print("  USGS 3DEP unavailable, falling back to Open-Meteo", file=sys.stderr)
+        return _fetch_elevations_open_meteo(coords)
+    return _fetch_elevations_usgs(coords)
+    return elevations
+
+
+# ---------------------------------------------------------------------------
+# GPX I/O
+# ---------------------------------------------------------------------------
+
+def gpx_to_coords(path):
+    """Read (lat, lng) and elevation from an existing GPX file.
+
+    Returns (coords, elevations) where elevations[i] may be None.
+    """
+    with open(path) as f:
+        gpx = gpxpy.parse(f)
+    coords = []
+    elevations = []
+    for track in gpx.tracks:
+        for segment in track.segments:
+            for pt in segment.points:
+                coords.append((pt.latitude, pt.longitude))
+                elevations.append(pt.elevation)
+    if not coords:
+        for route in gpx.routes:
+            for pt in route.points:
+                coords.append((pt.latitude, pt.longitude))
+                elevations.append(pt.elevation)
+    if not coords:
+        raise ValueError(f"No track or route points found in {path}")
+    return coords, elevations
+
+
+def compute_distance_mi(coords):
+    """Compute route distance in miles using haversine."""
+    total = 0.0
+    for i in range(1, len(coords)):
+        lat1, lon1 = math.radians(coords[i - 1][0]), math.radians(coords[i - 1][1])
+        lat2, lon2 = math.radians(coords[i][0]), math.radians(coords[i][1])
+        dlat = lat2 - lat1
+        dlon = lon2 - lon1
+        a = (
+            math.sin(dlat / 2) ** 2
+            + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+        )
+        total += 3958.8 * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return total
+
+
+def write_rcr_gpx(coords, elevations, route_id, route_name, output_path, map_url=None):
+    """Write a GPX file in the RCR project format."""
+    distance_mi = compute_distance_mi(coords)
+    today = date.today().isoformat()
+    ext_lines = []
+    if map_url:
+        ext_lines.append(f"      <rcr:map>{map_url}</rcr:map>")
+    ext_lines.append(f"      <rcr:last_updated>{today}</rcr:last_updated>")
+    extensions_block = "\n".join(ext_lines)
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+        '<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" '
+        'creator="Race Condition Running" '
+        'xmlns:rcr="http://raceconditionrunning.com/extensions">',
+        "  <metadata>",
+        f"    <name>{route_id}</name>",
+        f"    <desc>{route_name} ({distance_mi:.1f} mi)</desc>",
+        f'    <link href="https://raceconditionrunning.com/routes/{route_id}">',
+        f"      <text>Race Condition Running: {route_name}</text>",
+        "    </link>",
+        "    <author>",
+        "      <name>Race Condition Running</name>",
+        '      <link href="https://raceconditionrunning.com">',
+        "        <text>Race Condition Running</text>",
+        "      </link>",
+        "    </author>",
+        "    <extensions>",
+        extensions_block,
+        "    </extensions>",
+        "  </metadata>",
+        "  <trk>",
+        f"    <name>{route_id}</name>",
+        f"    <desc>{route_name} ({distance_mi:.1f} mi)</desc>",
+        "    <trkseg>",
+    ]
+    for (lat, lng), ele in zip(coords, elevations):
+        lines.append(
+            f'      <trkpt lat="{lat:.5f}" lon="{lng:.5f}">'
+            f"<ele>{ele:.2f}</ele></trkpt>"
+        )
+    lines.extend(["    </trkseg>", "  </trk>", "</gpx>"])
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# High-level conversions
+# ---------------------------------------------------------------------------
+
+def url_to_gpx(url, route_id, route_name, output_path, map_url=None):
+    """Convert an OnTheGoMap URL (short or long) to an RCR-format GPX file.
+
+    Fetches elevation from USGS 3DEP (falls back to Open-Meteo). If map_url
+    is not given, auto-generates a short URL. Returns the list of (lat, lng) coords.
+    """
+    coords = url_to_coords(url)
+    print(f"  decoded {len(coords)} track points")
+    print(f"Fetching elevation for {len(coords)} point(s)...")
+    elevations = fetch_elevations(coords)
+    if not map_url:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.path.startswith("/s/"):
+            map_url = url
+        else:
+            print("Generating short URL for map link...")
+            map_url = long_to_short_url(url)
+            print(f"  {map_url}")
+    write_rcr_gpx(coords, elevations, route_id, route_name, output_path, map_url)
+    return coords
+
+
+def gpx_to_url(gpx_path, short=False):
+    """Convert a GPX file to an OnTheGoMap URL.
+
+    If short=True, returns a shortened URL; otherwise returns the full URL.
+    """
+    coords, _ = gpx_to_coords(gpx_path)
+    long_url = coords_to_url(coords)
+    if short:
+        return long_to_short_url(long_url)
+    return long_url


### PR DESCRIPTION
Tried to remove some friction from route addition and improve documentation for the future.
1. Automation of route addition from a url or GPX. Almost no manual labor is needed now, once the route has been traced out.
2. README.md cleanup + additions. Documented the new feature, added missing information on setup, cleaned up the style and writing, added a filetree.

Planning to do a little more cleanup, but no new features planned (for now)