### PR TITLE
Drop duplicate osmnx declaration from the gis extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,5 @@ route-images = [
 ]
 gis = [
     "shapely",
-    "osmnx",
     "geopandas"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,6 @@ dependencies = [
 [package.optional-dependencies]
 gis = [
     { name = "geopandas" },
-    { name = "osmnx" },
     { name = "shapely" },
 ]
 route-images = [
@@ -496,7 +495,6 @@ requires-dist = [
     { name = "icalendar" },
     { name = "joblib" },
     { name = "osmnx", specifier = ">=2.0.6" },
-    { name = "osmnx", marker = "extra == 'gis'" },
     { name = "pillow", marker = "extra == 'route-images'" },
     { name = "playwright", marker = "extra == 'route-images'" },
     { name = "pyyaml" },


### PR DESCRIPTION
osmnx is a core dependency (`osmnx>=2.0.6`), so listing it again in the `gis` extra adds nothing -- extras install on top of the core set. The duplicate also crashes Dependabot's weekly uv scan ("Declaration not found for osmnx!" in its requirement replacer; see the Dependabot job log for Update #1462246407), which kept osmnx out of the grouped update PR #99 and would report a failed job every week.

Verified locally: `uv lock` resolves with no version changes (the diff is purely the two derived lines), the full site builds clean from sources, and osmnx 2.0.6 still installs and imports from core.